### PR TITLE
Fix Ubuntu build with system libzint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
           cmake ..
           make
           sudo make install
+          sudo ldconfig
 
       - name: macOS build zint
         if: matrix.os == 'macos' && matrix.builtin != 'true'


### PR DESCRIPTION
ffi-1.17.0 doesn't look any longer automatically into `/usr/local/lib` for libraries. Instead the `/etc/ld.so.conf` and `ld.so.cache` is used to find libraries. But new libraries needs to be added to the cache first in order to be found.