### PR TITLE
Add proper accessors for encoded_data and row_heigh and add Barcode#encode

### DIFF
--- a/spec/zint/barcode_spec.rb
+++ b/spec/zint/barcode_spec.rb
@@ -206,6 +206,15 @@ module Zint
         expect(strs[0].diameter).to be > 1.0
         expect(strs[0].rotation).to eq(0)
       end
+
+      it "encodes the barcode without export" do
+        b = barcode.encode
+        expect(b).to be(barcode)
+        expect(barcode.rows).to be > 0
+        expect(barcode.width).to be > 0
+        expect(barcode.encoded_data_as_array_of_strings).to be_kind_of(Array)
+        expect(barcode.encoded_data_as_array_of_strings[0]).to be_kind_of(String)
+      end
     end
 
     describe "attributes" do
@@ -343,15 +352,8 @@ module Zint
         expect(bc.structapp).to be_kind_of Structs::Structapp
       end
 
-      it "sets and gets text correctly" do
-        bc = Zint::Barcode.new text: "Täxt"
-
-        expect(bc.text).to eq "Täxt"
-      end
-
       it "provides text with checksum" do
-        barcode = Zint::Eanx.new(value: "123456789012")
-        barcode.to_buffer
+        barcode = Zint::Eanx.new(value: "123456789012").encode
         expect(barcode.text).to eq "1234567890128"
       end
 
@@ -367,16 +369,6 @@ module Zint
         bc = Zint::Barcode.new primary: "primary text"
 
         expect(bc.primary).to eq "primary text"
-      end
-
-      it "sets and gets encoded_data correctly" do
-        bc = Zint::Barcode.new encoded_data: "encoded_data"
-
-        expect(bc.encoded_data.to_s).to eq "encoded_data"
-      end
-
-      it "sets and gets row_height correctly" do
-        expect(barcode.row_height.to_a).to be_kind_of Array
       end
 
       it "gets errtxt correctly" do

--- a/spec/zint/data_matrix_spec.rb
+++ b/spec/zint/data_matrix_spec.rb
@@ -12,6 +12,20 @@ module Zint
       end
     end
 
+    it "provides encoded_data" do
+      enc = Zint::DataMatrix.new(value: "12345").encode.encoded_data_as_array_of_strings
+      expect(enc).to eq( ["1010101010",
+                          "1101100111",
+                          "1100010110",
+                          "1100110101",
+                          "1100111000",
+                          "1000011111",
+                          "1101011110",
+                          "1110000111",
+                          "1101100100",
+                          "1111111111"])
+    end
+
     describe "export" do
       it "export DataMatrix code" do
         dm_code = described_class.new(value: "/ACMRN123456/V200912190833")

--- a/spec/zint/eanx_spec.rb
+++ b/spec/zint/eanx_spec.rb
@@ -8,5 +8,10 @@ module Zint
         expect(File.read("spec/fixtures/eanx.svg")).to eq svg_file
       end
     end
+
+    it "provides encoded_data" do
+      enc = Zint::Eanx.new(value: "2092001474353").encode.encoded_data_as_array_of_strings
+      expect(enc).to eq ["10100011010001011001101101001110001101011001101010101110010001001011100100001010011101000010101"]
+    end
   end
 end

--- a/spec/zint/kix_spec.rb
+++ b/spec/zint/kix_spec.rb
@@ -7,6 +7,11 @@ module Zint
 
         expect(File.read("spec/fixtures/kix.svg")).to eq svg_file
       end
+
+      it "provides row_heights" do
+        heights = Zint::Kix.new(value: "130203").encode.row_heights
+        expect(heights).to eq [3.0, 2.0, 3.0]
+      end
     end
   end
 end


### PR DESCRIPTION
This avoids exposing FFI objects through the public API. The FFI objects are still exposed, but are marked as unstable. They might be used for debugging.

When only encoded_data_as_array_of_strings is used, then exporting a bitmap or vector is unnecessary. Therefore this patch adds Barcode#encode .

Also remove the write accessors of other output-only data.