### PR TITLE
Add blocking:true to all C calls

### DIFF
--- a/lib/zint/barcode.rb
+++ b/lib/zint/barcode.rb
@@ -86,7 +86,7 @@ module Zint
         call_function(:ZBarcode_Encode_and_Buffer, @zint_symbol, value, value.bytesize, rotate_angle)
       end
 
-      @zint_symbol[:bitmap].read_bytes((@zint_symbol[:bitmap_width] * @zint_symbol[:bitmap_height]))
+      @zint_symbol[:bitmap].read_bytes(@zint_symbol[:bitmap_width] * @zint_symbol[:bitmap_height])
     end
 
     # Exports barcode to buffer

--- a/lib/zint/native.rb
+++ b/lib/zint/native.rb
@@ -20,57 +20,57 @@ module Zint
     typedef :pointer, :source
 
     # Create and initialize a symbol structure
-    attach_function(:ZBarcode_Create, [], :zint_symbol)
+    attach_function(:ZBarcode_Create, [], :zint_symbol, blocking: true)
 
     # Free any output buffers that may have been created and initialize output fields
-    attach_function(:ZBarcode_Clear, [:zint_symbol], :void)
+    attach_function(:ZBarcode_Clear, [:zint_symbol], :void, blocking: true)
 
     # Free a symbol structure, including any output buffers
     #
     # For use with ruby's garbage collector ZBarcode_Delete must be called with a plain :pointer and not an :zint_symbol.
-    attach_function(:ZBarcode_Delete, [:pointer], :void)
+    attach_function(:ZBarcode_Delete, [:pointer], :void, blocking: true)
 
     # Encode a barcode. If `length` is 0, `source` must be NUL-terminated.
-    attach_function(:ZBarcode_Encode, [:zint_symbol, :source, :length], :error_code)
+    attach_function(:ZBarcode_Encode, [:zint_symbol, :source, :length], :error_code, blocking: true)
 
     # Encode a barcode using input data from file `filename`
-    attach_function(:ZBarcode_Encode_File, [:zint_symbol, :filename], :error_code)
+    attach_function(:ZBarcode_Encode_File, [:zint_symbol, :filename], :error_code, blocking: true)
 
     # Output a previously encoded symbol to file `symbol->outfile`
-    attach_function(:ZBarcode_Print, [:zint_symbol, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Print, [:zint_symbol, :rotate_angle], :error_code, blocking: true)
 
     # Encode and output a symbol to file `symbol->outfile`
-    attach_function(:ZBarcode_Encode_and_Print, [:zint_symbol, :source, :length, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Encode_and_Print, [:zint_symbol, :source, :length, :rotate_angle], :error_code, blocking: true)
 
     # Encode a symbol using input data from file `filename` and output to file `symbol->outfile`
-    attach_function(:ZBarcode_Encode_File_and_Print, [:zint_symbol, :filename, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Encode_File_and_Print, [:zint_symbol, :filename, :rotate_angle], :error_code, blocking: true)
 
     # Output a previously encoded symbol to memory as raster (`symbol->bitmap`)
-    attach_function(:ZBarcode_Buffer, [:zint_symbol, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Buffer, [:zint_symbol, :rotate_angle], :error_code, blocking: true)
 
     # Encode and output a symbol to memory as raster (`symbol->bitmap`)
-    attach_function(:ZBarcode_Encode_and_Buffer, [:zint_symbol, :source, :length, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Encode_and_Buffer, [:zint_symbol, :source, :length, :rotate_angle], :error_code, blocking: true)
 
     # Encode a symbol using input data from file `filename` and output to memory as raster (`symbol->bitmap`)
-    attach_function(:ZBarcode_Encode_File_and_Buffer, [:zint_symbol, :filename, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Encode_File_and_Buffer, [:zint_symbol, :filename, :rotate_angle], :error_code, blocking: true)
 
     # Output a previously encoded symbol to memory as vector (`symbol->vector`)
-    attach_function(:ZBarcode_Buffer_Vector, [:zint_symbol, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Buffer_Vector, [:zint_symbol, :rotate_angle], :error_code, blocking: true)
 
     # Encode and output a symbol to memory as vector (`symbol->vector`)
-    attach_function(:ZBarcode_Encode_and_Buffer_Vector, [:zint_symbol, :source, :length, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Encode_and_Buffer_Vector, [:zint_symbol, :source, :length, :rotate_angle], :error_code, blocking: true)
 
     # Encode a symbol using input data from file `filename` and output to memory as vector (`symbol->vector`)
-    attach_function(:ZBarcode_Encode_File_and_Buffer_Vector, [:zint_symbol, :filename, :rotate_angle], :error_code)
+    attach_function(:ZBarcode_Encode_File_and_Buffer_Vector, [:zint_symbol, :filename, :rotate_angle], :error_code, blocking: true)
 
     # Is `symbol_id` a recognized symbology?
-    attach_function(:ZBarcode_ValidID, [:symbol_id], :bool)
+    attach_function(:ZBarcode_ValidID, [:symbol_id], :bool, blocking: true)
 
     # Return the capability flags for symbology `symbol_id` that match `cap_flag`
-    attach_function(:ZBarcode_Cap, [:symbol_id, :cap_flag], :uint32)
+    attach_function(:ZBarcode_Cap, [:symbol_id, :cap_flag], :uint32, blocking: true)
 
     # Return the version of Zint linked to
-    attach_function(:ZBarcode_Version, [], :int32)
+    attach_function(:ZBarcode_Version, [], :int32, blocking: true)
 
     # Raises specific error for API return code
     #


### PR DESCRIPTION
... so that the GVL is released as long as the call takes. Even though Zint is quite fast, it can take around 10 ms to encode a big PDF417 symbology. While that time other ruby threads are unnecessary blocked, when the GVL is not released.

The additional cost for releasing the GVL is so minimal that it is usually not relevant.